### PR TITLE
Update requests package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ MarkupSafe==1.0
 oauthlib==2.1.0
 pyasn1==0.4.4
 pyasn1-modules==0.2.2
-requests==2.19.1
+requests==2.20.1
 requests-oauthlib==1.0.0
 rsa==3.4.2
 six==1.11.0


### PR DESCRIPTION
Based On Security Alert. Update from 2.19.1

Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.
https://nvd.nist.gov/vuln/detail/CVE-2018-18074
